### PR TITLE
feat: report errors to a webhook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,3 +61,4 @@ jobs:
           --extra-vars DISCORD_TOKEN=${{secrets.BOT_TOKEN}}
           --extra-vars GUILD=${{vars.GUILD_ID}}
           --extra-vars HF_TOKEN=${{secrets.HF_TOKEN}}
+          --extra-vars ERROR_WH=${{secrets.ERROR_WH}}

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -17,5 +17,6 @@
         DISCORD_TOKEN: '{{ DISCORD_TOKEN }}'
         GUILD_ID: '{{ GUILD }}'
         HF_TOKEN: '{{ HF_TOKEN }}'
+        ERROR_WH: '{{ ERROR_WH }}'
         DB_CONN: mongodb://172.17.0.1
       pull: true

--- a/frontroomsbot/consts.py
+++ b/frontroomsbot/consts.py
@@ -6,5 +6,6 @@ TOKEN = os.getenv("DISCORD_TOKEN")
 GUILD = os.getenv("GUILD_ID")
 HF_TOKEN = os.getenv("HF_TOKEN")
 DB_CONN = os.getenv("DB_CONN")
+ERROR_WH = os.getenv("ERROR_WH")
 
 COGS_DIR = "cogs"


### PR DESCRIPTION
Using a webhook prevents using up API limits for
an error loop.