### PR TITLE
Fix for timeout in private channels

### DIFF
--- a/frontroomsbot/cogs/reaction_utils.py
+++ b/frontroomsbot/cogs/reaction_utils.py
@@ -75,12 +75,12 @@ class ReactionUtilsCog(ConfigCog):
                 react.emoji == "🔇"
                 and not author.is_timed_out()
                 and not message.is_system()
-                and react.count >= self.timeout_count
+                and react.count >= await self.timeout_count
             ):
                 # FIXME
                 # we need to maintain when was the last timeout,
                 # otherwise someone could get locked out
-                duration = datetime.timedelta(minutes=self.timeout_duration)
+                duration = datetime.timedelta(minutes=await self.timeout_duration)
                 await author.timeout(duration)
                 break
 

--- a/frontroomsbot/cogs/reaction_utils.py
+++ b/frontroomsbot/cogs/reaction_utils.py
@@ -70,17 +70,18 @@ class ReactionUtilsCog(ConfigCog):
         :return
         """
         for react in message.reactions:
+            author = await message.guild.fetch_member(message.author.id)
             if (
                 react.emoji == "🔇"
-                and not message.author.is_timed_out()
+                and not author.is_timed_out()
                 and not message.is_system()
-                and react.count >= await self.timeout_count
+                and react.count >= self.timeout_count
             ):
                 # FIXME
                 # we need to maintain when was the last timeout,
                 # otherwise someone could get locked out
-                duration = datetime.timedelta(minutes=await self.timeout_duration)
-                await message.author.timeout(duration)
+                duration = datetime.timedelta(minutes=self.timeout_duration)
+                await author.timeout(duration)
                 break
 
 


### PR DESCRIPTION
> A Member that sent the message. If channel is a private channel or the user has the left the guild, then it is a User instead.
https://discordpy.readthedocs.io/en/stable/api.html?highlight=channel#discord.Message.author

Due to backrooms being a private channel, timeout did not work as the message's author was a User, not a Member.