### PR TITLE
Various changes to help development

### DIFF
--- a/frontroomsbot/bot.py
+++ b/frontroomsbot/bot.py
@@ -21,15 +21,14 @@ class BackroomsBot(commands.Bot):
         super().__init__(*args, **kwargs)
         db_client = ma.AsyncIOMotorClient(DB_CONN)
         self.db = db_client.bot_database
+        self.backrooms = guild
 
-    async def on_ready(self):
+    async def setup_hook(self):
         for filename in os.listdir(COGS_DIR):
             if filename.endswith("py") and not filename.startswith("_"):
                 await self.load_extension(
                     f"{'.'.join(COGS_DIR.split('/'))}.{filename[:-3]}"
                 )
-
-        print(f"{self.user} has connected to Discord!")
 
     async def on_error(self, event: str, *args, **kwargs):
         content = StringIO()

--- a/frontroomsbot/cogs/config_cog.py
+++ b/frontroomsbot/cogs/config_cog.py
@@ -48,4 +48,4 @@ class ConfigCommands(commands.Cog):
 
 async def setup(bot):
     clear_cache()
-    await bot.add_cog(ConfigCommands(bot), guild=bot.guilds[0])
+    await bot.add_cog(ConfigCommands(bot), guild=bot.backrooms)

--- a/frontroomsbot/cogs/devtools.py
+++ b/frontroomsbot/cogs/devtools.py
@@ -1,0 +1,53 @@
+from bot import BackroomsBot
+from discord.ext import commands
+from consts import ERROR_WH
+import httpx
+from pathlib import Path
+import time
+
+# strip filename, leave cogs/, then frontroomsbot/
+DOT_GIT = Path(__file__).parent.parent.parent / ".git"
+
+
+class DevTools(commands.Cog):
+    def __init__(self, bot: BackroomsBot) -> None:
+        self.bot = bot
+
+    def doctor(self):
+        """
+        Run various self-checks to find common problems with the bot deployment
+        """
+        guilds = list(self.bot.guilds)
+        assert (
+            guilds[0].id == self.bot.backrooms.id
+        ), f"The configured GUILD_ID is not the guild the bot is in, {self.bot.backrooms.id} vs {guilds[0].id}"
+        assert len(guilds) == 1, "The bot is in multiple guilds"
+
+        bad_commands = []
+        for cmd in self.bot.tree.walk_commands():
+            if not cmd.guild_only:
+                bad_commands.append(cmd)
+        if bad_commands:
+            raise RuntimeError(
+                f"Found commands that aren't guild only: {bad_commands}, these will not sync via /sync"
+            )
+        print("self check ok")
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        print("bot ready, running self check")
+        self.doctor()
+        try:
+            git_revision = (DOT_GIT / "refs/heads/master").read_text()
+        except IOError:
+            git_revision = "git revision not found"
+        data = {
+            "content": f"{self.bot.user} is up at <t:{int(time.time())}:T> using git: `{git_revision.strip()}`.",
+            "allowed_mentions": {"parse": []},
+        }
+        async with httpx.AsyncClient() as cl:
+            await cl.post(ERROR_WH, json=data)
+
+
+async def setup(bot):
+    await bot.add_cog(DevTools(bot), guild=bot.backrooms)

--- a/frontroomsbot/cogs/llm.py
+++ b/frontroomsbot/cogs/llm.py
@@ -101,4 +101,4 @@ class LLMCog(ConfigCog):
 
 
 async def setup(bot: BackroomsBot) -> None:
-    await bot.add_cog(LLMCog(bot), guild=bot.guilds[0])
+    await bot.add_cog(LLMCog(bot), guild=bot.backrooms)

--- a/frontroomsbot/cogs/message_utils.py
+++ b/frontroomsbot/cogs/message_utils.py
@@ -25,4 +25,4 @@ class StringUtilsCog(commands.Cog):
 
 
 async def setup(bot: BackroomsBot) -> None:
-    await bot.add_cog(StringUtilsCog(bot), guild=bot.guilds[0])
+    await bot.add_cog(StringUtilsCog(bot), guild=bot.backrooms)

--- a/frontroomsbot/cogs/misc.py
+++ b/frontroomsbot/cogs/misc.py
@@ -49,4 +49,4 @@ class MiscellaneousCog(commands.Cog):
 
 
 async def setup(bot: BackroomsBot) -> None:
-    await bot.add_cog(MiscellaneousCog(bot), guild=bot.guilds[0])
+    await bot.add_cog(MiscellaneousCog(bot), guild=bot.backrooms)

--- a/frontroomsbot/cogs/random_utils.py
+++ b/frontroomsbot/cogs/random_utils.py
@@ -51,4 +51,4 @@ class RandomUtilsCog(commands.Cog):
 
 
 async def setup(bot: BackroomsBot) -> None:
-    await bot.add_cog(RandomUtilsCog(bot), guild=bot.guilds[0])
+    await bot.add_cog(RandomUtilsCog(bot), guild=bot.backrooms)

--- a/frontroomsbot/cogs/reaction_utils.py
+++ b/frontroomsbot/cogs/reaction_utils.py
@@ -87,4 +87,4 @@ class ReactionUtilsCog(ConfigCog):
 
 async def setup(bot: BackroomsBot) -> None:
     bot.add_view(BookmarkView())
-    await bot.add_cog(ReactionUtilsCog(bot), guild=bot.guilds[0])
+    await bot.add_cog(ReactionUtilsCog(bot), guild=bot.backrooms)


### PR DESCRIPTION
This change moves bot startup logic to `setup_hook` to let cogs listen to `on_ready` (it is also apparently correct overall).

This sadly means that we have to rely on `GUILD_ID` rather than bot.guilds inside cogs. In order to make this less painful, startup checks are added to ensure `GUILD_ID` is correct.

The bot will now announce when it restarts to the `ERROR_WH`, making it easier to see when the bot redeploys.