### PR TITLE
Make the build faster if a new dependency is added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,13 @@ ENV PYTHONDONTWRITEBYTECODE 1
 
 WORKDIR /app
 
-COPY pyproject.toml poetry.lock /app/
-
 RUN pip install poetry
 RUN poetry config virtualenvs.create false
-RUN poetry install
 RUN adduser --shell /bin/bash bot
+
+COPY pyproject.toml poetry.lock /app/
+
+RUN poetry install
 
 USER bot
 


### PR DESCRIPTION
Before, changing poetry.lock would invalidate the docker cache on pip install poetry, which is an operation that takes about a minute. This fixes that.