### PR TITLE
Improve the bots error tolerance

### DIFF
--- a/frontroomsbot/bot.py
+++ b/frontroomsbot/bot.py
@@ -23,32 +23,52 @@ class BackroomsBot(commands.Bot):
         self.db = db_client.bot_database
         self.backrooms = guild
 
-    async def setup_hook(self):
+    def list_extensions(self):
         for filename in os.listdir(COGS_DIR):
             if filename.endswith("py") and not filename.startswith("_"):
-                await self.load_extension(
-                    f"{'.'.join(COGS_DIR.split('/'))}.{filename[:-3]}"
-                )
+                yield f"{'.'.join(COGS_DIR.split('/'))}.{filename[:-3]}"
 
-    async def on_error(self, event: str, *args, **kwargs):
-        content = StringIO()
-        print_exc(file=content)
-        print(content.getvalue())
+    async def setup_hook(self):
+        # make sure aaa_extensions is first
+        for name in sorted(self.list_extensions()):
+            try:
+                await self.load_extension(name)
+            except Exception:
+                content = StringIO()
+                print_exc(file=content)
+                print(content.getvalue())
+                await self.send_wh(f"extension {name} failed", content.getvalue())
+
+    async def send_wh(self, title: str, msg: str = ""):
+        if not ERROR_WH:
+            print("No webhook set, not sending")
+            return
         data = {
-            "content": f"Bot ran into an error in event {event!r} with \n`{args=!r}`\n`{kwargs=!r}`",
+            "content": title,
             "allowed_mentions": {"parse": []},
             "embeds": [
                 {
                     "title": "Traceback",
-                    "description": "```" + content.getvalue()[-3950:] + "```",
+                    "description": "```" + msg[-3950:] + "```",
                 }
             ],
         }
+        if not msg:
+            del data["embeds"]
         async with httpx.AsyncClient() as cl:
             # use a webhook instead of the discord connection in
             # case the error is caused by being disconnected from discord
             # also prevents error reporting from breaking API limits
             await cl.post(ERROR_WH, json=data)
+
+    async def on_error(self, event: str, *args, **kwargs):
+        content = StringIO()
+        print_exc(file=content)
+        print(content.getvalue())
+        await self.send_wh(
+            f"Bot ran into an error in event {event!r} with \n`{args=!r}`\n`{kwargs=!r}`",
+            content.getvalue(),
+        )
 
 
 client = BackroomsBot(command_prefix="!", intents=intents)

--- a/frontroomsbot/cogs/aaa_extensions.py
+++ b/frontroomsbot/cogs/aaa_extensions.py
@@ -1,0 +1,64 @@
+# should be loaded first and not use the DB or config
+
+import discord
+from discord.ext import commands
+from discord import app_commands
+
+from bot import BackroomsBot
+
+
+@app_commands.checks.has_permissions(moderate_members=True)
+class MetaCog(commands.GroupCog, group_name="extensions"):
+    def __init__(self, bot: BackroomsBot) -> None:
+        self.bot = bot
+
+    @app_commands.command(
+        name="status", description="List all extensions and their status"
+    )
+    async def cogs(self, interaction: discord.Interaction):
+        all_extensions = set(self.bot.list_extensions())
+        loaded_extensions = self.bot.extensions.keys()
+        lines = []
+        if not (all_extensions >= loaded_extensions):
+            lines.append(
+                f"found surplus extensions: {loaded_extensions - all_extensions}"
+            )
+        for ext in sorted(all_extensions):
+            char = (
+                "\N{WHITE HEAVY CHECK MARK}"
+                if ext in loaded_extensions
+                else "\N{CROSS MARK}"
+            )
+            lines.append(f"## {char} {ext}")
+            if ext in self.bot.extensions:
+                mod = self.bot.extensions[ext]
+                for name, v in vars(mod).items():
+                    if (
+                        isinstance(v, type)
+                        and issubclass(v, commands.Cog)
+                        and name != "ConfigCog"
+                    ):
+                        cog_char = (
+                            "\N{WHITE HEAVY CHECK MARK}"
+                            if self.bot.get_cog(v.__cog_name__)
+                            else "\N{CROSS MARK}"
+                        )
+                        lines.append(f" - {cog_char} {name}")
+        await interaction.response.send_message("\n".join(lines))
+
+    @app_commands.command(name="load", description="(re)Load a specific extension")
+    async def load(self, interaction: discord.Interaction, ext: str):
+        if ext in self.bot.extensions:
+            await self.bot.reload_extension(ext)
+        else:
+            await self.bot.load_extension(ext)
+        await interaction.response.send_message(f"Extension {ext} loaded.")
+
+    @app_commands.command(name="unload", description="unload a specific extension")
+    async def unload(self, interaction: discord.Interaction, ext: str):
+        await self.bot.unload_extension(ext)
+        await interaction.response.send_message(f"Extension {ext} loaded.")
+
+
+async def setup(bot: BackroomsBot) -> None:
+    await bot.add_cog(MetaCog(bot), guild=bot.backrooms)

--- a/frontroomsbot/cogs/config_cog.py
+++ b/frontroomsbot/cogs/config_cog.py
@@ -1,7 +1,7 @@
 from bot import BackroomsBot
 from discord.ext import commands
 from discord import app_commands, Interaction
-from ._config import ConfigCog, clear_cache, gen_modal
+from ._config import ConfigCog, clear_cache, gen_modal, get_unloaded_cog
 
 
 class ConfigCommands(commands.Cog):
@@ -35,15 +35,17 @@ class ConfigCommands(commands.Cog):
         else:
             cog_instance = self.bot.get_cog(cog.__cog_name__)
             if not cog_instance:
-                await interaction.response.send_message(
-                    "That cog is not loaded", ephemeral=True
+                cog_instance = get_unloaded_cog(cog_module)
+                await interaction.response.send_modal(
+                    await gen_modal(cog_module, cog.options, cog_instance)
                 )
-            assert isinstance(
-                cog_instance, ConfigCog
-            ), "Found a non-configurable cog, perhaps two cogs live in the same module"
-            await interaction.response.send_modal(
-                await gen_modal(cog_module, cog.options, cog_instance)
-            )
+            else:
+                assert isinstance(
+                    cog_instance, ConfigCog
+                ), f"Found a non-configurable cog, perhaps two cogs live in the same module - {cog_instance!r}"
+                await interaction.response.send_modal(
+                    await gen_modal(cog_module, cog.options, cog_instance)
+                )
 
 
 async def setup(bot):

--- a/frontroomsbot/cogs/devtools.py
+++ b/frontroomsbot/cogs/devtools.py
@@ -1,7 +1,5 @@
 from bot import BackroomsBot
 from discord.ext import commands
-from consts import ERROR_WH
-import httpx
 from pathlib import Path
 import time
 
@@ -41,12 +39,9 @@ class DevTools(commands.Cog):
             git_revision = (DOT_GIT / "refs/heads/master").read_text()
         except IOError:
             git_revision = "git revision not found"
-        data = {
-            "content": f"{self.bot.user} is up at <t:{int(time.time())}:T> using git: `{git_revision.strip()}`.",
-            "allowed_mentions": {"parse": []},
-        }
-        async with httpx.AsyncClient() as cl:
-            await cl.post(ERROR_WH, json=data)
+        await self.bot.send_wh(
+            f"{self.bot.user} is up at <t:{int(time.time())}:T> using git: `{git_revision.strip()}`."
+        )
 
 
 async def setup(bot):

--- a/frontroomsbot/cogs/random_utils.py
+++ b/frontroomsbot/cogs/random_utils.py
@@ -12,7 +12,10 @@ class RandomUtilsCog(commands.Cog):
 
     @app_commands.command(name="roll", description="Rolls a number")
     async def roll(
-        self, interaction: discord.Interaction, first: int = 100, second: int = None
+        self,
+        interaction: discord.Interaction,
+        first: int = 100,
+        second: int | None = None,
     ):
         if second is None:
             result = randint(0, first)

--- a/frontroomsbot/consts.py
+++ b/frontroomsbot/consts.py
@@ -2,11 +2,11 @@ import os
 from dotenv import load_dotenv
 
 load_dotenv()
-TOKEN = os.getenv("DISCORD_TOKEN")
-GUILD = os.getenv("GUILD_ID")
-HF_TOKEN = os.getenv("HF_TOKEN")
-GEMINI_TOKEN = os.getenv("GEMINI_TOKEN")
-DB_CONN = os.getenv("DB_CONN")
-ERROR_WH = os.getenv("ERROR_WH")
+TOKEN = os.environ["DISCORD_TOKEN"]
+GUILD = os.environ["GUILD_ID"]
+HF_TOKEN = os.environ.get("HF_TOKEN")
+GEMINI_TOKEN = os.environ.get("GEMINI_TOKEN")
+DB_CONN = os.environ.get("DB_CONN")
+ERROR_WH = os.environ.get("ERROR_WH")
 
 COGS_DIR = "cogs"


### PR DESCRIPTION
The basic idea is to forcibly unload a cog if it fails due to a configuration error, then provide the commands to get reload it once the configuration is fixed.

Beyond that, llm is made to not report transient failures to the error webhook to hopefully make the signal to noise ratio better with it.